### PR TITLE
new Balanceable type

### DIFF
--- a/src/Hedgehog/Plutus/Tx.hs
+++ b/src/Hedgehog/Plutus/Tx.hs
@@ -17,13 +17,14 @@ import Data.Vector qualified as Vector
 
 import Cardano.Crypto.Hash.Class (hashToBytes)
 import Cardano.Ledger.Alonzo.Tx qualified as Ledger
-import Cardano.Ledger.BaseTypes (Network)
+import Cardano.Ledger.BaseTypes (Network, txIxFromIntegral)
 import Cardano.Ledger.Core qualified as Core
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Mary.Value qualified as MV
 import Cardano.Ledger.Shelley.API.Wallet (CLI, evaluateTransactionBalance)
 import Cardano.Ledger.Shelley.Scripts (ScriptHash (ScriptHash))
 import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody)
+import Cardano.Ledger.TxIn qualified as Ledger
 
 import Plutus.Model qualified as Model
 import Plutus.Model.Fork.Cardano.Alonzo qualified as Alonzo
@@ -534,11 +535,31 @@ data CoreTx
   | Babbage (Core.Tx Babbage.Era)
 
 -- | Generate the relevant transaction fragment for a 'ScriptPurpose'
-scriptPurposeTx :: TxContext -> ScriptPurpose -> Tx 'Unbalanced
-scriptPurposeTx = _
+scriptPurposeTx :: ScriptPurpose -> Tx 'Unbalanced
+scriptPurposeTx = \case
+  Spending ref inscript ->
+    mempty
+      { txInputs = Set.singleton $ TxIn ref (Just inscript)
+      }
+  Minting cs (toks, red) ->
+    mempty
+      { txMint = Map.singleton cs (toks, red)
+      }
 
 {- | Generate a ledger 'Ledger.ScriptPurpose' from a @hedgehog-plutus-simple@
  'ScriptPurpose'.
 -}
 toLedgerScriptPurpose :: ScriptPurpose -> Ledger.ScriptPurpose era
-toLedgerScriptPurpose = _
+toLedgerScriptPurpose = \case
+  Spending (Plutus.TxOutRef (Plutus.TxId txIdHash) idx) _inscript ->
+    Ledger.Spending $
+      Ledger.TxIn
+        (Ledger.TxId $ error "TODO convert this hash" txIdHash)
+        (fromMaybe (error "index overflow") $ txIxFromIntegral idx)
+  -- The Maybe is because the integer might not fit in a Word64
+  -- This shouldn't come up in practice
+  Minting (Plutus.CurrencySymbol sh) _ ->
+    Ledger.Minting $
+      MV.PolicyID $
+        ScriptHash $
+          error "TODO find a way to convert this type" sh

--- a/src/Hedgehog/Plutus/Tx.hs
+++ b/src/Hedgehog/Plutus/Tx.hs
@@ -25,8 +25,10 @@ where
 
 import Control.Arrow ((>>>))
 import Control.Monad (guard, liftM2)
+
 import Data.ByteString.Short qualified as SBS
 import Data.Coerce (coerce)
+import Data.Function ((&))
 import Data.Functor (($>))
 import Data.Map qualified as Map
 import Data.Map.Strict (Map)
@@ -67,13 +69,12 @@ import PlutusLedgerApi.V1.Address qualified as Plutus
 import PlutusLedgerApi.V1.Interval qualified as Plutus
 import PlutusLedgerApi.V1.Tx (RedeemerPtr (RedeemerPtr), ScriptTag (Mint))
 import PlutusLedgerApi.V1.Value qualified as Plutus
+import PlutusLedgerApi.V2 (OutputDatum (NoOutputDatum, OutputDatum, OutputDatumHash))
 import PlutusLedgerApi.V2 qualified as Plutus
 import PlutusTx.Lattice ((/\))
 
-import Data.Function ((&))
 import Hedgehog qualified
 import Hedgehog.Gen qualified as Gen
-import PlutusLedgerApi.V2 (OutputDatum (NoOutputDatum, OutputDatum, OutputDatumHash))
 
 data Balanced = Balanced | Unbalanced
 

--- a/src/Hedgehog/Plutus/TxTest.hs
+++ b/src/Hedgehog/Plutus/TxTest.hs
@@ -20,23 +20,25 @@ import Hedgehog qualified
 
 import Hedgehog.Plutus.Adjunction (Adjunction (Adjunction, left, right))
 import Hedgehog.Plutus.Tx (
+  Balanceable,
   Balanced (Unbalanced),
   ScriptPurpose,
   Tx,
   TxContext,
   scriptPurposeTx,
+  unbalanced,
  )
 
 data ScriptTx = ScriptTx
   { scriptTxPurpose :: ScriptPurpose
-  , scriptTx :: Tx 'Unbalanced
+  , scriptTx :: Balanceable 'Unbalanced Tx
   -- ^ The remainder of the transaction, not including the purposes's mint/spend
   }
 
 data family Bad ingrs
 
-txForScriptTx :: TxContext -> ScriptTx -> Tx 'Unbalanced
-txForScriptTx _ctx (ScriptTx sp tx) = tx <> scriptPurposeTx sp
+txForScriptTx :: TxContext -> ScriptTx -> Balanceable 'Unbalanced Tx
+txForScriptTx _ctx (ScriptTx sp tx) = tx <> unbalanced (scriptPurposeTx sp)
 
 newtype TxTest ingrs = TxTest (Adjunction (Either (Bad ingrs) ingrs) ScriptTx)
 

--- a/src/Hedgehog/Plutus/TxTest.hs
+++ b/src/Hedgehog/Plutus/TxTest.hs
@@ -20,25 +20,22 @@ import Hedgehog qualified
 
 import Hedgehog.Plutus.Adjunction (Adjunction (Adjunction, left, right))
 import Hedgehog.Plutus.Tx (
-  Balanceable,
-  Balanced (Unbalanced),
   ScriptPurpose,
   Tx,
   TxContext,
   scriptPurposeTx,
-  unbalanced,
  )
 
 data ScriptTx = ScriptTx
   { scriptTxPurpose :: ScriptPurpose
-  , scriptTx :: Balanceable 'Unbalanced Tx
+  , scriptTx :: Tx
   -- ^ The remainder of the transaction, not including the purposes's mint/spend
   }
 
 data family Bad ingrs
 
-txForScriptTx :: TxContext -> ScriptTx -> Balanceable 'Unbalanced Tx
-txForScriptTx _ctx (ScriptTx sp tx) = tx <> unbalanced (scriptPurposeTx sp)
+txForScriptTx :: TxContext -> ScriptTx -> Tx
+txForScriptTx _ctx (ScriptTx sp tx) = tx <> scriptPurposeTx sp
 
 newtype TxTest ingrs = TxTest (Adjunction (Either (Bad ingrs) ingrs) ScriptTx)
 

--- a/src/Hedgehog/Plutus/TxTest.hs
+++ b/src/Hedgehog/Plutus/TxTest.hs
@@ -1,14 +1,31 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 
-module Hedgehog.Plutus.TxTest where
+module Hedgehog.Plutus.TxTest (
+  txTest,
+  ScriptTx (..),
+  Bad,
+  TxTest (..),
+  txForScriptTx,
+  txTestBad,
+  txTestGood,
+  txTestRight,
+  txTestTestBad,
+  txTestTestGood,
+) where
 
 import Data.Kind (Type)
 
 import Hedgehog ((===))
 import Hedgehog qualified
 
-import Hedgehog.Plutus.Adjunction
-import Hedgehog.Plutus.Tx
+import Hedgehog.Plutus.Adjunction (Adjunction (Adjunction, left, right))
+import Hedgehog.Plutus.Tx (
+  Balanced (Unbalanced),
+  ScriptPurpose,
+  Tx,
+  TxContext,
+  scriptPurposeTx,
+ )
 
 data ScriptTx = ScriptTx
   { scriptTxPurpose :: ScriptPurpose
@@ -19,7 +36,7 @@ data ScriptTx = ScriptTx
 data family Bad ingrs
 
 txForScriptTx :: TxContext -> ScriptTx -> Tx 'Unbalanced
-txForScriptTx ctx (ScriptTx sp tx) = tx <> scriptPurposeTx ctx sp
+txForScriptTx _ctx (ScriptTx sp tx) = tx <> scriptPurposeTx sp
 
 newtype TxTest ingrs = TxTest (Adjunction (Either (Bad ingrs) ingrs) ScriptTx)
 


### PR DESCRIPTION
The `Tx (bal :: Balanced)` made it tricky to create a safe API. This changes the types a bit to make that possible.
Adding
```haskell
newtype Balanced tx = UnsafeBalance tx

type family MaybeBalanced (balanced :: Bool) tx where
  MaybeBalanced 'True tx = Balanced tx
  MaybeBalanced 'False tx = tx

  -- | Get a plain tx out of a Balanced tx or MaybeBalanced bal tx
getTx :: IsBool bal => MaybeBalanced bal tx -> tx

-- and then a few internal function use UnsafeBalance
confirmBalanced :: TxContext -> Tx -> Maybe (Balanced Tx)

toSimpleModelTx ::
  forall (bal :: Bool).
  IsBool bal =>
  TxContext ->
  MaybeBalanced bal Tx ->
  MaybeBalanced bal Model.Tx

toLedgerTx ::
  forall (bal :: Bool).
  IsBool bal =>
  TxContext ->
  MaybeBalanced bal Tx ->
  MaybeBalanced bal CoreTx
```
These should be the only functions capable of creating terms of type `Balanced a` (aside from things like `coerce` `error` `undefined` `fix id` etc). So we should be able to have some type level assurances for rather a tx is balanced.