### PR TITLE
psm haddock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8531,16 +8531,17 @@
         "plutus": "plutus_4"
       },
       "locked": {
-        "lastModified": 1672153441,
-        "narHash": "sha256-uiMXQSr7XAbuA+2OIjlgITS+W0qVwZaMcUNco+gj148=",
+        "lastModified": 1674642357,
+        "narHash": "sha256-PnS9hGvBGquddnY7x0Jjd69xI4Q3jHG2D0b4mSPFP/g=",
         "owner": "mlabs-haskell",
         "repo": "mlabs-tooling.nix",
-        "rev": "3367df5cffc9e6823e88a3b6ac2dae55682a4d15",
+        "rev": "f1e8e9def136b57f38be9c255e1c8228a5fafdea",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "mlabs-tooling.nix",
+        "rev": "f1e8e9def136b57f38be9c255e1c8228a5fafdea",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -7582,16 +7582,16 @@
         "tooling": "tooling_3"
       },
       "locked": {
-        "lastModified": 1673283368,
-        "narHash": "sha256-fkiQX9ROSAywUdJAg/ziEELH9uq1sc5L6cqRJYfcVgU=",
+        "lastModified": 1675708193,
+        "narHash": "sha256-mwR5Qk9+wA8uSgxF16/gH++nOTVzo1wHa/C17es2/a0=",
         "owner": "mlabs-haskell",
         "repo": "plutus-simple-model",
-        "rev": "05fa4a29061d3c849e26bfc873c6b288b085c742",
+        "rev": "6726588be11b2510e65b7f84bcaf296300bf66cb",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
-        "ref": "ari/expose-tx",
+        "ref": "ari/remove-plutus-tx",
         "repo": "plutus-simple-model",
         "type": "github"
       }
@@ -8507,11 +8507,11 @@
         "plutus": "plutus_3"
       },
       "locked": {
-        "lastModified": 1671582351,
-        "narHash": "sha256-SrNXbfheBuXTW8brxg//fHSbV249UlpWTQAg+3UPAHk=",
+        "lastModified": 1674642357,
+        "narHash": "sha256-PnS9hGvBGquddnY7x0Jjd69xI4Q3jHG2D0b4mSPFP/g=",
         "owner": "mlabs-haskell",
         "repo": "mlabs-tooling.nix",
-        "rev": "2376c911c6f8b6dcf46f479afddd671b3d37de78",
+        "rev": "f1e8e9def136b57f38be9c255e1c8228a5fafdea",
         "type": "github"
       },
       "original": {
@@ -8531,17 +8531,17 @@
         "plutus": "plutus_4"
       },
       "locked": {
-        "lastModified": 1674642357,
-        "narHash": "sha256-PnS9hGvBGquddnY7x0Jjd69xI4Q3jHG2D0b4mSPFP/g=",
+        "lastModified": 1675710483,
+        "narHash": "sha256-p9G02LNHHNfx3afO6aH7h1DdikGu4ugQjpEQqaxk+lE=",
         "owner": "mlabs-haskell",
         "repo": "mlabs-tooling.nix",
-        "rev": "f1e8e9def136b57f38be9c255e1c8228a5fafdea",
+        "rev": "516e38050899b624d66e8e744d22a3136024a275",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "mlabs-tooling.nix",
-        "rev": "f1e8e9def136b57f38be9c255e1c8228a5fafdea",
+        "rev": "516e38050899b624d66e8e744d22a3136024a275",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -10,9 +10,9 @@
   };
 
   inputs = {
-    tooling.url = "github:mlabs-haskell/mlabs-tooling.nix?rev=f1e8e9def136b57f38be9c255e1c8228a5fafdea";
+    tooling.url = "github:mlabs-haskell/mlabs-tooling.nix?rev=516e38050899b624d66e8e744d22a3136024a275";
 
-    plutus-simple-model.url = "github:mlabs-haskell/plutus-simple-model?ref=ari/expose-tx";
+    plutus-simple-model.url = "github:mlabs-haskell/plutus-simple-model?ref=ari/remove-plutus-tx";
 
     plutarch.url = "github:Plutonomicon/plutarch-plutus";
   };
@@ -26,6 +26,12 @@
           project.extraHackage = [
             "${plutus-simple-model}"
             "${plutarch}"
+          ];
+          toHaddock = [
+            "plutarch"
+            "plutus-ledger-api"
+            "cardano-crypto"
+            "plutus-simple-model"
           ];
         })
       ];

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,14 @@
 
   nixConfig = {
     extra-experimental-features = [ "nix-command" "flakes" "ca-derivations" ];
-    extra-substituters = [ "https://cache.iog.io" "https://public-plutonomicon.cachix.org" ];
+    extra-substituters = [ "https://cache.iog.io" ];
     extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" "public-plutonomicon.cachix.org-1:3AKJMhCLn32gri1drGuaZmFrmnue+KkKrhhubQk/CWc=" ];
     allow-import-from-derivation = "true";
     bash-prompt = "\\[\\e[0m\\][\\[\\e[0;2m\\]nix \\[\\e[0;1m\\]hps \\[\\e[0;93m\\]\\w\\[\\e[0m\\]]\\[\\e[0m\\]$ \\[\\e[0m\\]";
   };
 
   inputs = {
-    tooling.url = "github:mlabs-haskell/mlabs-tooling.nix";
+    tooling.url = "github:mlabs-haskell/mlabs-tooling.nix?rev=f1e8e9def136b57f38be9c255e1c8228a5fafdea";
 
     plutus-simple-model.url = "github:mlabs-haskell/plutus-simple-model?ref=ari/expose-tx";
 


### PR DESCRIPTION
This pr uses the remove-plutus-tx branch of psm and a bracnh of mlabs-tooling where the psm override is removed to make haddock work. The `toHaddock` options are almost certainly a subset of what we will eventually want, but I think it's fine to add things to that as they are needed.

This is in draft mode because it currently depends on unmerged features in psm and mlabs-tooling.