### PR TITLE
use cardano-simple

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7582,17 +7582,16 @@
         "tooling": "tooling_3"
       },
       "locked": {
-        "lastModified": 1675782761,
+        "lastModified": 1675784500,
         "narHash": "sha256-YIWRyXvHxsi+XQB/pOHOc3pyJU04H16nGPIrZepEbRE=",
         "owner": "mlabs-haskell",
         "repo": "plutus-simple-model",
-        "rev": "6031cec64fe76d3cc2b805b310194be9ae3a5750",
+        "rev": "387e0baa2234ab7a8f228148218bb8a1e090962e",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "plutus-simple-model",
-        "rev": "6031cec64fe76d3cc2b805b310194be9ae3a5750",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -7582,17 +7582,17 @@
         "tooling": "tooling_3"
       },
       "locked": {
-        "lastModified": 1673283368,
-        "narHash": "sha256-fkiQX9ROSAywUdJAg/ziEELH9uq1sc5L6cqRJYfcVgU=",
+        "lastModified": 1675782761,
+        "narHash": "sha256-YIWRyXvHxsi+XQB/pOHOc3pyJU04H16nGPIrZepEbRE=",
         "owner": "mlabs-haskell",
         "repo": "plutus-simple-model",
-        "rev": "05fa4a29061d3c849e26bfc873c6b288b085c742",
+        "rev": "6031cec64fe76d3cc2b805b310194be9ae3a5750",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
-        "ref": "ari/expose-tx",
         "repo": "plutus-simple-model",
+        "rev": "6031cec64fe76d3cc2b805b310194be9ae3a5750",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
   inputs = {
     tooling.url = "github:mlabs-haskell/mlabs-tooling.nix";
 
-    plutus-simple-model.url = "github:mlabs-haskell/plutus-simple-model?rev=6031cec64fe76d3cc2b805b310194be9ae3a5750";
+    plutus-simple-model.url = "github:mlabs-haskell/plutus-simple-model";
 
     plutarch.url = "github:Plutonomicon/plutarch-plutus";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
   inputs = {
     tooling.url = "github:mlabs-haskell/mlabs-tooling.nix";
 
-    plutus-simple-model.url = "github:mlabs-haskell/plutus-simple-model?ref=ari/expose-tx";
+    plutus-simple-model.url = "github:mlabs-haskell/plutus-simple-model?rev=6031cec64fe76d3cc2b805b310194be9ae3a5750";
 
     plutarch.url = "github:Plutonomicon/plutarch-plutus";
   };
@@ -24,7 +24,8 @@
           project.src = ./.;
 
           project.extraHackage = [
-            "${plutus-simple-model}"
+            "${plutus-simple-model}/psm"
+            "${plutus-simple-model}/cardano-simple"
             "${plutarch}"
           ];
         })

--- a/hedgehog-plutus-simple.cabal
+++ b/hedgehog-plutus-simple.cabal
@@ -106,6 +106,7 @@ library
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-ledger-shelley-ma
+    , cardano-simple
     , cardano-slotting
     , containers
     , hedgehog

--- a/src/Hedgehog/Plutus/TestSingleScript.hs
+++ b/src/Hedgehog/Plutus/TestSingleScript.hs
@@ -37,8 +37,8 @@ import PlutusLedgerApi.Common qualified as Plutus
 import PlutusLedgerApi.V2 qualified as Plutus hiding (evaluateScriptCounting)
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC
 
+import Cardano.Simple.Ledger.TimeSlot qualified as Fork
 import Plutus.Model qualified as Model
-import Plutus.Model.Fork.Ledger.TimeSlot qualified as Fork
 import Plutus.Model.Mock.ProtocolParameters qualified as Model
 
 import Hedgehog ((===))

--- a/src/Hedgehog/Plutus/Tx.hs
+++ b/src/Hedgehog/Plutus/Tx.hs
@@ -51,14 +51,14 @@ import Cardano.Ledger.Shelley.Scripts (ScriptHash (ScriptHash))
 import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody)
 import Cardano.Ledger.TxIn qualified as Ledger
 
+import Cardano.Simple.Cardano.Alonzo qualified as Alonzo
+import Cardano.Simple.Cardano.Babbage qualified as Babbage
+import Cardano.Simple.Cardano.Class qualified as Class
+import Cardano.Simple.Ledger.Scripts (scriptHash)
+import Cardano.Simple.Ledger.TimeSlot qualified as Time
+import Cardano.Simple.Ledger.Tx qualified as Fork
+import Cardano.Simple.PlutusLedgerApi.V1.Scripts qualified as Scripts
 import Plutus.Model qualified as Model
-import Plutus.Model.Fork.Cardano.Alonzo qualified as Alonzo
-import Plutus.Model.Fork.Cardano.Babbage qualified as Babbage
-import Plutus.Model.Fork.Cardano.Class qualified as Class
-import Plutus.Model.Fork.Ledger.Scripts (scriptHash)
-import Plutus.Model.Fork.Ledger.TimeSlot qualified as Time
-import Plutus.Model.Fork.Ledger.Tx qualified as Fork
-import Plutus.Model.Fork.PlutusLedgerApi.V1.Scripts qualified as Scripts
 import Plutus.Model.Mock.ProtocolParameters qualified as Model
 
 import PlutusCore qualified as PLC
@@ -542,14 +542,16 @@ toLedgerTx context tx =
   where
     cont :: Class.IsCardanoTx era => Core.PParams era -> Core.Tx era
     cont params =
-      Class.toCardanoTx
-        (Map.map convertScript $ interestingScripts context)
-        (Model.mockConfigNetworkId $ Model.mockConfig $ mockchain context)
-        params
-        (toSimpleModelTx context tx)
-        & \case
-          Left e -> error ("toLedgerTx failed with:" <> show e)
-          Right tx -> tx
+      let Model.Tx extra ptx = toSimpleModelTx context tx
+       in Class.toCardanoTx
+            (Map.map convertScript $ interestingScripts context)
+            (Model.mockConfigNetworkId $ Model.mockConfig $ mockchain context)
+            params
+            extra
+            ptx
+            & \case
+              Left e -> error ("toLedgerTx failed with:" <> show e)
+              Right tx -> tx
 
 -- Since toLedgerTx can't actually be polymorphic
 -- as the era is forced by the mockchain


### PR DESCRIPTION
Uses the psm branch that seperates out the cardano-simple package. `cabal build` was already failing due to type holes, so this may introduce errors that aren't coming up, but the ones that did I fixed.