### PR TITLE
add cat-prelude

### DIFF
--- a/cat-prelude/Catagory/Prelude.hs
+++ b/cat-prelude/Catagory/Prelude.hs
@@ -1,0 +1,9 @@
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+module Catagory.Prelude (
+  module Prelude,
+  Category ((.), id),
+) where
+
+import Control.Category (Category (id, (.)))
+import Prelude hiding (id, (.))

--- a/flake.lock
+++ b/flake.lock
@@ -8531,11 +8531,11 @@
         "plutus": "plutus_4"
       },
       "locked": {
-        "lastModified": 1675797045,
-        "narHash": "sha256-FO6MX9hcXoTf2bUyO5o2BTlzKDVtLSuBX2lOwsLEcQs=",
+        "lastModified": 1676568601,
+        "narHash": "sha256-SpaWDzk+6WweLAEPOrcOMo5Wh5+dongOQFFpupb36n8=",
         "owner": "mlabs-haskell",
         "repo": "mlabs-tooling.nix",
-        "rev": "6f78b002ab2c477a928a9332b6e0e18828cffc62",
+        "rev": "097996e58595077b91f729c033ea893725827df7",
         "type": "github"
       },
       "original": {

--- a/hedgehog-plutus-simple.cabal
+++ b/hedgehog-plutus-simple.cabal
@@ -91,6 +91,10 @@ common common-lang
 
 library
   import:          common-lang
+  mixins:
+    base hiding (Prelude),
+    cat-prelude (Catagory.Prelude as Prelude)
+
   exposed-modules:
     Hedgehog.Plutus.Adjunction
     Hedgehog.Plutus.AuctionExample
@@ -110,6 +114,7 @@ library
     , cardano-ledger-shelley
     , cardano-simple
     , cardano-slotting
+    , cat-prelude
     , containers
     , generics-sop
     , hedgehog
@@ -123,3 +128,8 @@ library
     , vector
 
   hs-source-dirs:  src
+
+library cat-prelude
+  exposed-modules: Catagory.Prelude
+  hs-source-dirs:  cat-prelude
+  build-depends:   base

--- a/hedgehog-plutus-simple.cabal
+++ b/hedgehog-plutus-simple.cabal
@@ -92,9 +92,19 @@ common common-lang
 library
   import:          common-lang
   exposed-modules: Hedgehog.Plutus.Simple
+  mixins:
+    base hiding (Prelude),
+    cat-prelude (Catagory.Prelude as Prelude)
+
   build-depends:
+    , cat-prelude
     , hedgehog
     , plutus-ledger-api
     , plutus-simple-model
 
   hs-source-dirs:  src
+
+library cat-prelude
+  exposed-modules: Catagory.Prelude
+  hs-source-dirs:  cat-prelude
+  build-depends:   base

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,5 +1,8 @@
 cradle:
   cabal:
+    - path: "./cat-prelude"
+      component: "lib:hedgehog-plutus-simple:cat-prelude"
+
     - path: "./src"
       component: "lib:hedgehog-plutus-simple"
 

--- a/src/Hedgehog/Plutus/Adjunction.hs
+++ b/src/Hedgehog/Plutus/Adjunction.hs
@@ -8,11 +8,7 @@ module Hedgehog.Plutus.Adjunction (
   adjunctionTest,
 ) where
 
-import Prelude hiding (id, (.))
-
 import Data.Kind (Type)
-
-import Control.Category (Category (id, (.)))
 
 import Hedgehog ((===))
 import Hedgehog qualified

--- a/src/Hedgehog/Plutus/TxTest.hs
+++ b/src/Hedgehog/Plutus/TxTest.hs
@@ -4,12 +4,8 @@ module Hedgehog.Plutus.TxTest where
 
 import Data.Kind (Constraint, Type)
 
-import Prelude hiding ((.))
-
 import PlutusLedgerApi.V2 qualified as Plutus
 import PlutusTx.AssocMap qualified
-
-import Control.Category (Category ((.)))
 
 import Plutus.Model qualified as Model
 


### PR DESCRIPTION
Replaces base Prelude with one that replaces `id` and `.`  with Control.Catagory and adds the `Catagory` class.
Mostly useful for avoiding the no explicit import list you get with `import Prelude hiding ((.),id)`.