### PR TITLE
Switch to Tasty

### DIFF
--- a/hedgehog-plutus-simple.cabal
+++ b/hedgehog-plutus-simple.cabal
@@ -185,6 +185,9 @@ test-suite hedgehog-plutus-simple
     , plutus-core
     , plutus-ledger-api
     , plutus-simple-model
+    , tasty
+    , tasty-hedgehog
+    , tasty-hunit
     , text
 
 library cat-prelude

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,12 +1,13 @@
-import Hedgehog (checkParallel)
-import Hedgehog.Main (defaultMain)
+import Test.Tasty
 
 import Time (timeTests)
 import TxValid (txValidTests)
 
 main :: IO ()
 main =
-  defaultMain
-    [ checkParallel timeTests
-    , checkParallel txValidTests
-    ]
+  defaultMain $
+    testGroup
+      "implementation tests"
+      [ timeTests
+      , txValidTests
+      ]

--- a/test/Time.hs
+++ b/test/Time.hs
@@ -3,6 +3,8 @@ module Time where
 import Hedgehog (Gen, Group (Group), Property, forAll, property)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+import Test.Tasty qualified as Tasty
+import Test.Tasty.Hedgehog qualified as Tasty
 
 import Cardano.Simple.Ledger.Slot (Slot, SlotRange)
 import Cardano.Simple.Ledger.TimeSlot (
@@ -20,13 +22,14 @@ import PlutusLedgerApi.V2 (
 
 import Hedgehog.Plutus.Adjunction (Adjunction (Adjunction), adjunctionTest)
 
-timeTests :: Group
+timeTests :: Tasty.TestTree
 timeTests =
-  Group
-    "time adjunction"
-    [ ("from POSIX", fromPosix)
-    , ("from Slot", fromSlot)
-    ]
+  Tasty.fromGroup $
+    Group
+      "time adjunction"
+      [ ("from POSIX", fromPosix)
+      , ("from Slot", fromSlot)
+      ]
 
 fromPosix :: Property
 fromPosix = property $ do


### PR DESCRIPTION
Allows making the script tests into unit tests, rather than superfluous property tests.